### PR TITLE
Add support for SSH proxy.

### DIFF
--- a/lib/capistrano/rails/console/tasks/remote.cap
+++ b/lib/capistrano/rails/console/tasks/remote.cap
@@ -12,8 +12,14 @@ namespace :rails do
   desc "Interact with a remote rails console"
   task console: ['deploy:set_rails_env'] do
     on primary :app do |host|
+      ssh_options = fetch(:ssh_options)
+      if ssh_options && ssh_options[:proxy]
+        template = ssh_options[:proxy].command_line_template
+        proxy_options = "-o ProxyCommand=\"#{template}\""
+      end
+
       user_host = [host.user, host.hostname].compact.join('@')
-      ssh_cmd = "ssh #{user_host} -p #{host.port || 22}"
+      ssh_cmd = "ssh #{proxy_options} #{user_host} -p #{host.port || 22}"
 
       cmd = SSHKit::Command.new(:rails, "console #{fetch :rails_env}", host: host)
       SSHKit.config.output << cmd


### PR DESCRIPTION
We use capistrano with a jump host which is defined like this:

set :ssh_options, {
  proxy: Net::SSH::Proxy::Command.new('ssh user@ourcompany.nl -W %h:%p'),
  forward_agent: true
}

This PR adds support for starting the rails console via the proxy.

I did not test it without the proxy host!