### PR TITLE
add `-o HostName` option to ssh command if :host_name key exist in ssh_options

### DIFF
--- a/lib/capistrano/rails/console/tasks/remote.cap
+++ b/lib/capistrano/rails/console/tasks/remote.cap
@@ -19,6 +19,10 @@ namespace :rails do
         ssh_cmd_args << "-o ProxyCommand=\"#{template}\""
       end
 
+      if host.ssh_options && host.ssh_options[:host_name]
+        ssh_cmd_args << "-o HostName=\"#{host.ssh_options[:host_name]}\""
+      end
+
       rails_console_args << '--sandbox' if ENV.key?('sandbox') || ENV.key?('s')
 
       rails_env = fetch(:rails_env, fetch(:stage, 'production'))


### PR DESCRIPTION
When I set :host_name in config/deploy/sandbox.rb:

```ruby
server 'sandbox-server01', user: 'user01', roles: %w{web app db}, ssh_options: { host_name: 'x.x.x.x' }
```

`cap sandbox rails:console` failed as follows:

```
ssh: Could not resolve hostname sandbox-server01: Name or service not known
```

This pull request adds `-o HostName="x.x.x.x"` option to ssh command and fixes this problem.
