### PR TITLE
Use a login shell when spawning the rails console

### DIFF
--- a/lib/capistrano/rails/console/tasks/remote.cap
+++ b/lib/capistrano/rails/console/tasks/remote.cap
@@ -45,7 +45,7 @@ namespace :rails do
         ssh_cmd_args << "-i #{identity}"
       end
 
-      ssh_cmd = %Q(ssh #{ssh_cmd_args.join(' ')} -t "cd #{current_path} && (#{cmd.environment_string} #{cmd})")
+      ssh_cmd = %Q(ssh #{ssh_cmd_args.join(' ')} -t '$SHELL -l -c "cd #{current_path} && (#{cmd.environment_string} #{cmd})"')
 
       debug("Running #{ssh_cmd.yellow} on #{host.hostname.blue}")
 


### PR DESCRIPTION
Otherwise the shell profile doesn't get loaded, and that can break for example
chruby.