### PR TITLE
Fix SSHKit NoMethodError 'environment_string'

### DIFF
--- a/capistrano-rails-console.gemspec
+++ b/capistrano-rails-console.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capistrano',             '>= 3.1.0', '< 4.0.0'
   spec.add_dependency 'capistrano-interactive', '~> 0.2.0'
 
+  spec.add_dependency 'sshkit', '>= 1.4'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
SSHKit::Command#environment_string doesn't exist in sshkit 1.3 due to a
bug/typo, causing NoMethodError when running `cap <stage> rails:console`

Bug was fixed in https://github.com/capistrano/sshkit/commit/f3955d1a,
which was included in 1.4.0, so update gemspec to require sshkit >= 1.4