### PR TITLE
Add compatibility with Rbenv and Chruby

### DIFF
--- a/lib/capistrano/rails/console/tasks.cap
+++ b/lib/capistrano/rails/console/tasks.cap
@@ -1,7 +1,10 @@
 namespace :load do
   task :defaults do
-    # Add rails to rvm_map_bins
-    set :rvm_map_bins, fetch(:rvm_map_bins, []).push(:rails)
+    # Add rails to RVM, Rbenv and Chruby bins
+    %i{rvm_map_bins rbenv_map_bins chruby_map_bins}.each do |bins_var|
+        bins = fetch(bins_var, [])
+        set bins_var, bins.push('rails') unless bins.include?('rails')
+    end
 
     # Default values
     set :console_env,  -> { fetch(:rails_env, fetch(:stage, 'production')) }


### PR DESCRIPTION
It was not working for me using Chruby, with this patch it does.
I also added rbenv compatibility since the internals of all (capistrano-rvm, capistrano-rbenv, capistrano-chruby) are implemented the same way.