### PR TITLE
Add rails:db alias to rails:dbconsole

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You can also start a sandbox session:
 Or run a dbconsole:
 
     $ cap production rails:dbconsole
+    $ cap production rails:db
 
 ## Options
 

--- a/lib/capistrano/rails/console/tasks.cap
+++ b/lib/capistrano/rails/console/tasks.cap
@@ -37,4 +37,6 @@ namespace :rails do
       end
     end
   end
+
+  task db: :dbconsole
 end


### PR DESCRIPTION
As to [official Rails documentation "The Rails Command Line", section "Command Line Basics"](http://guides.rubyonrails.org/command_line.html#rails-dbconsole), there is an alias for `rake dbconsole` – `rake db`. It will be convenient to have this shortcut in this gem too, as far as some people may rely on it.